### PR TITLE
Add main class to application

### DIFF
--- a/examples/evaluate-hardened-openstack/build.gradle.kts
+++ b/examples/evaluate-hardened-openstack/build.gradle.kts
@@ -5,3 +5,5 @@ dependencies {
     api(project(":codyze-query-catalog"))
     api(project(":codyze-technology-openstack"))
 }
+
+application { mainClass = "example.MainKt" }


### PR DESCRIPTION
The gradle build skript lacks the main file, which causes the CLI command not to work as specified by the Readme. This PR fixes this issue.